### PR TITLE
海报插件更新1.0.1版本

### DIFF
--- a/plugins/showPoster/index.html
+++ b/plugins/showPoster/index.html
@@ -1,0 +1,74 @@
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="https://cdn.staticfile.org/jquery/1.9.0/jquery.min.js" ></script>
+        <script src="https://cdn.staticfile.org/mousetrap/1.4.6/mousetrap.min.js" ></script>
+    </head>
+    <body>
+        <img style="margin-bottom:5px;" id="AigisPoster" src="#" onerror="javascript:this.src=getNextUrl(this)" />
+    </body>
+    <script>
+        imgUrlPrefix = "http://assets.millennium-war.net/00/html/image/event";
+        imgUrlSuffix = ".jpg";
+        $().ready(function(){
+            var now = new Date();
+            $("#AigisPoster").attr("data",now.getTime());
+            $("#AigisPoster").attr("alt",imgUrlPrefix+formatDate(now)+imgUrlSuffix);
+            $("#AigisPoster").attr("src",imgUrlPrefix+formatDate(now)+imgUrlSuffix);
+        });
+        function getLastThursday(date){
+            var dateTemp = new Date();
+            if(date != null){
+                dateTemp = change2Yesterday(date);
+            }
+        	if(dateTemp.getDay()!=4){
+        		dateTemp.setDate(dateTemp.getDate()-dateTemp.getDay()-3);
+    		}
+    		return dateTemp;
+        }
+        function change2Yesterday(date){
+        	date.setDate(date.getDate()-1);
+        	return date;
+        }
+        function formatDate(date){
+        	var year = date.getYear()+1900;
+        	var monthStr = date.getMonth()+1;
+        	monthStr = monthStr >=10?monthStr+"":"0"+monthStr;
+        	var dateStr = date.getDate();
+        	dateStr = dateStr >=10?dateStr+"":"0"+dateStr;
+        	return year+monthStr+dateStr;
+        }
+        function requestNoReferer(url,accept,func){
+        	var isExists = false;
+		    $.ajax({
+		        method: 'GET',
+		        url: url,
+		        async : false, 
+		        complete: function(e,xhr,settings){
+		        	if(e.status+"" == "200"){
+		        		isExists = true;
+		        	}
+		        }
+		    });
+		    return isExists;
+		}
+        function getNextUrl(imgEle){
+            var readDateLong = parseInt($(imgEle).attr("data"));
+            var nowLong = new Date().getTime();
+            if(nowLong-readDateLong >= 864000000){
+                imgEle.onerror = function (){return false;};
+                return "#";
+            }
+            else{
+                var beforeDays = change2Yesterday(new Date(readDateLong));
+                var dateStr = formatDate(beforeDays);
+                $(imgEle).attr("data",beforeDays.getTime());
+                return imgUrlPrefix+dateStr+imgUrlSuffix;
+            }
+        }
+        Mousetrap.bind("left",function(){window.moveBy(-1,0)});
+        Mousetrap.bind("right",function(){window.moveBy(1,0)});
+        Mousetrap.bind("up",function(){window.moveBy(0,-1);return false;});
+        Mousetrap.bind("down",function(){window.moveBy(0,1);return false;});
+    </script>
+</html>

--- a/plugins/showPoster/manifest.json
+++ b/plugins/showPoster/manifest.json
@@ -1,0 +1,16 @@
+{
+    "pluginName":"showPoster",
+    "author":"Serializable",
+    "version":"1.0.1",
+    "description":"显示海报",
+    "entry":"index.html",
+    "enable":true,
+    "windowOption":{
+        "width":1020,
+        "height":700,
+        "title":"海报",
+        "minimizable":true,
+        "maximizable":false,
+        "resizable":true
+    }
+}


### PR DESCRIPTION
修复无法显示海报的问题

nga由于未激活无法发言和修改，也无法私信，所以使用pull request更新
本次pull request中的所有文件在CC0下发布